### PR TITLE
Bugfix/failed jobs migration

### DIFF
--- a/database/migrations/2023_08_06_130541_create_failed_jobs_table.php
+++ b/database/migrations/2023_08_06_130541_create_failed_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('failed_jobs');
+    }
+};

--- a/database/migrations/2023_08_06_133831_create_jobs_table.php
+++ b/database/migrations/2023_08_06_133831_create_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('jobs');
+    }
+};


### PR DESCRIPTION
## Description

Make a failed jobs and jobs table so mailables can be queued and run without failing

## How accurate is this to the original issue?

Needed to also make a jobs table 

## List of new features / improvements:

- Failed jobs table
- Jobs table

## What went well:

- Made failed jobs table and managed to manually test the system easily

## What didn't go well:

- Didn't realise I had to have a jobs table as well 
- Didn't realise I proably didn't need a regression test since queuing is all laravel built and generated

## How to improve next time:

- Better scoping - research

## Ways it was tested:

- [x] Unit Tests
- [ ] Postman
- [x] Manual Testing

## Extra Notes
